### PR TITLE
Allow debug logging to be enabled via environment variable

### DIFF
--- a/signal_scanner_bot/bin/run.py
+++ b/signal_scanner_bot/bin/run.py
@@ -2,6 +2,10 @@ import logging
 
 import click
 
+from signal_scanner_bot import env
+from signal_scanner_bot.signal_scanner_bot import listen_and_print
+
+
 log = logging.getLogger(__name__)
 
 logging.basicConfig(
@@ -13,12 +17,15 @@ logging.basicConfig(
 @click.command()
 @click.option("-d", "--debug", is_flag=True)
 def cli(debug: bool) -> None:
-    if debug:
+    if debug or env.DEBUG:
         logging.getLogger().setLevel(logging.DEBUG)
-    log.info("Listening...")
+        env.log_vars()
 
-    # Local import so env vars are logged at debug
-    from signal_scanner_bot.signal_scanner_bot import listen_and_print
+        # These are super noisy
+        for _log in ["requests", "oauthlib", "requests_oauthlib", "urllib3"]:
+            logging.getLogger(_log).setLevel(logging.INFO)
+
+    log.info("Listening...")
 
     listen_and_print()
 

--- a/signal_scanner_bot/env.py
+++ b/signal_scanner_bot/env.py
@@ -1,19 +1,30 @@
 import logging
 import os
-from typing import Optional
+from typing import Optional, Any
 
 
 log = logging.getLogger(__name__)
 
 
-def _env(key: str, fail: bool = True) -> Optional[str]:
+_VARS = []
+
+
+def _env(key: str, fail: bool = True, default: Any = None) -> Optional[str]:
     value = os.environ.get(key)
-    if value is None and fail:
-        raise KeyError(f"Key '{key}' is not present in environment!")
-    log.debug(f"{key}={value}")
+    if value is None:
+        if fail:
+            raise KeyError(f"Key '{key}' is not present in environment!")
+        return default
+    _VARS.append((key, value))
     return value
 
 
+def log_vars() -> None:
+    for key, value in _VARS:
+        log.debug(f"{key}={value}")
+
+
+DEBUG = _env("DEBUG", fail=False, default=False)
 BOT_NUMBER = _env("BOT_NUMBER")
 ADMIN_NUMBER = _env("ADMIN_NUMBER")
 LISTEN_GROUP = _env("LISTEN_GROUP", fail=False)


### PR DESCRIPTION
This PR makes it so that the container can be run while logging at the debug level by changing the DEBUG environment variable to anything truthy.

Example runs:
```bash
$ dc run --rm cli python signal_scanner_bot/bin/run.py 
[2020-08-13 02:42:24,215 - __main__ -  28][INFO] Listening...
[2020-08-13 02:42:25,814 - signal_scanner_bot.signal_scanner_bot -  37][WARNING] STDERR: User is not registered.
[2020-08-13 02:42:25,814 - signal_scanner_bot.signal_scanner_bot -  39][INFO] Killing signal-cli
$ dc run -e DEBUG=true --rm cli python signal_scanner_bot/bin/run.py 
[2020-08-13 02:42:30,352 - signal_scanner_bot.env -  24][DEBUG] DEBUG=true
[2020-08-13 02:42:30,352 - signal_scanner_bot.env -  24][DEBUG] BOT_NUMBER=...
[2020-08-13 02:42:30,353 - signal_scanner_bot.env -  24][DEBUG] ADMIN_NUMBER=...
[2020-08-13 02:42:30,353 - signal_scanner_bot.env -  24][DEBUG] LISTEN_GROUP=...
[2020-08-13 02:42:30,353 - signal_scanner_bot.env -  24][DEBUG] TWITTER_API_KEY=...
[2020-08-13 02:42:30,353 - signal_scanner_bot.env -  24][DEBUG] TWITTER_API_SECRET=...
[2020-08-13 02:42:30,353 - signal_scanner_bot.env -  24][DEBUG] TWITTER_ACCESS_TOKEN=...
[2020-08-13 02:42:30,353 - signal_scanner_bot.env -  24][DEBUG] TWITTER_TOKEN_SECRET=...
[2020-08-13 02:42:30,353 - __main__ -  28][INFO] Listening...
[2020-08-13 02:42:30,353 - tweepy.binder - 108][DEBUG] PARAMS: {}
[2020-08-13 02:42:32,047 - signal_scanner_bot.signal_scanner_bot -  37][WARNING] STDERR: User is not registered.
[2020-08-13 02:42:32,048 - signal_scanner_bot.signal_scanner_bot -  39][INFO] Killing signal-cli
```

Resolves #7 