### PR TITLE
Bump signal-cli version to latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-slim
 ENV PIP_NO_CACHE_DIR=1 \
     JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/ \
     PYTHONPATH=/app \
-    SIGNAL_CLI_VERSION=0.6.8
+    SIGNAL_CLI_VERSION=0.6.10
 
 # Install OpenJDK-8
 RUN apt-get update && \


### PR DESCRIPTION
This version was just released recently and we're experiencing a few issues with the CLI so I thought it prudent to update.
