### PR TITLE
BUGFIX: Fix Twitter URL for web and mobile

### DIFF
--- a/signal_scanner_bot/messages.py
+++ b/signal_scanner_bot/messages.py
@@ -123,5 +123,5 @@ def process_twitter_message(status: Status) -> None:
     # Remove hashtags
     text_split = [word for word in text.split() if not word.startswith("#")]
     text = " ".join(text_split)
-    text += f"\nhttps://twitter.com/statuses/{status.id}"
+    text += f"\nhttps://twitter.com/i/status/{status.id}"
     signal.send_message(text, env.LISTEN_GROUP, group=True)


### PR DESCRIPTION
This PR fixes the twitter URL that's added to statuses the bot sends out to Signal. Previously the links worked on mobile but not on web - now they work on both.

Resolves #16 