### PR TITLE
BUGFIX: Enable stalling on warnings while filtering messages

### DIFF
--- a/signal_scanner_bot/transport.py
+++ b/signal_scanner_bot/transport.py
@@ -40,7 +40,7 @@ def _twitter_to_signal():
     api = twitter.get_api()
     stream = tweepy.Stream(auth=api.auth, listener=Listener())
     log.info("Stream initialized, starting to follow")
-    stream.filter(track=twitter.RECEIVE_HASHTAGS)
+    stream.filter(track=twitter.RECEIVE_HASHTAGS, stall_warnings=True)
 
 
 async def twitter_to_signal():


### PR DESCRIPTION
This PR adds a flag to the `API::filter` call to try and prevent the bot from crashing when it's falling behind while processing messages.
