### PR TITLE
Detect if sender is group, unify contact interface

### DIFF
--- a/signal_scanner_bot/env.py
+++ b/signal_scanner_bot/env.py
@@ -34,8 +34,8 @@ def log_vars() -> None:
 
 DEBUG = _env("DEBUG", default=False)
 BOT_NUMBER = _env("BOT_NUMBER")
-ADMIN_NUMBER = _env("ADMIN_NUMBER")
-LISTEN_GROUP = _env("LISTEN_GROUP", fail=False)
+ADMIN_CONTACT = _env("ADMIN_CONTACT")
+LISTEN_CONTACT = _env("LISTEN_CONTACT", fail=False)
 SIGNAL_TIMEOUT = _env("SIGNAL_TIMEOUT", default=10)
 TWITTER_API_KEY = _env("TWITTER_API_KEY")
 TWITTER_API_SECRET = _env("TWITTER_API_SECRET")

--- a/signal_scanner_bot/filters.py
+++ b/signal_scanner_bot/filters.py
@@ -38,7 +38,9 @@ def _f_no_group(data: Dict) -> bool:
 def _f_wrong_group(data: Dict) -> bool:
     # Listen group is defined but ID doesn't match
     group = data.get("groupInfo") or {}
-    return bool(group and env.LISTEN_CONTACT and group.get("groupId") != env.LISTEN_CONTACT)
+    return bool(
+        group and env.LISTEN_CONTACT and group.get("groupId") != env.LISTEN_CONTACT
+    )
 
 
 def _f_not_recent(data: Dict) -> bool:

--- a/signal_scanner_bot/filters.py
+++ b/signal_scanner_bot/filters.py
@@ -32,13 +32,13 @@ def _f_no_data(data: Dict) -> bool:
 
 def _f_no_group(data: Dict) -> bool:
     # If listen group is defined and there's not group info
-    return bool(env.LISTEN_GROUP and not data.get("groupInfo"))
+    return bool(env.LISTEN_CONTACT and not data.get("groupInfo"))
 
 
 def _f_wrong_group(data: Dict) -> bool:
     # Listen group is defined but ID doesn't match
     group = data.get("groupInfo") or {}
-    return bool(group and env.LISTEN_GROUP and group.get("groupId") != env.LISTEN_GROUP)
+    return bool(group and env.LISTEN_CONTACT and group.get("groupId") != env.LISTEN_CONTACT)
 
 
 def _f_not_recent(data: Dict) -> bool:

--- a/signal_scanner_bot/messages.py
+++ b/signal_scanner_bot/messages.py
@@ -105,7 +105,7 @@ def process_signal_message(blob: Dict, api: API) -> None:
         return
     log.info(notice)
     env.STATE.LISTENING = listening
-    signal.send_message(notice, env.LISTEN_GROUP, group=True)
+    signal.send_message(notice, env.LISTEN_GROUP)
 
 
 def process_twitter_message(status: Status) -> None:
@@ -128,4 +128,4 @@ def process_twitter_message(status: Status) -> None:
     text_split = [word for word in text.split() if not word.startswith("#")]
     text = " ".join(text_split)
     text += f"\nhttps://twitter.com/i/status/{status.id}"
-    signal.send_message(text, env.LISTEN_GROUP, group=True)
+    signal.send_message(text, env.LISTEN_GROUP)

--- a/signal_scanner_bot/messages.py
+++ b/signal_scanner_bot/messages.py
@@ -105,7 +105,7 @@ def process_signal_message(blob: Dict, api: API) -> None:
         return
     log.info(notice)
     env.STATE.LISTENING = listening
-    signal.send_message(notice, env.LISTEN_GROUP)
+    signal.send_message(notice, env.LISTEN_CONTACT)
 
 
 def process_twitter_message(status: Status) -> None:
@@ -128,4 +128,4 @@ def process_twitter_message(status: Status) -> None:
     text_split = [word for word in text.split() if not word.startswith("#")]
     text = " ".join(text_split)
     text += f"\nhttps://twitter.com/i/status/{status.id}"
-    signal.send_message(text, env.LISTEN_GROUP)
+    signal.send_message(text, env.LISTEN_CONTACT)

--- a/signal_scanner_bot/signal.py
+++ b/signal_scanner_bot/signal.py
@@ -51,6 +51,6 @@ def send_message(message: str, recipient: Optional[str]):
 def panic(err: Exception) -> None:
     # We don't really care if this succeeds, particularly if there's an issue
     # with the signal config
-    log.info(f"Panicing, attempting to call home at {env.ADMIN_NUMBER}")
+    log.info(f"Panicing, attempting to call home at {env.ADMIN_CONTACT}")
     message = f"BOT FAILURE: {err}\n{traceback.format_exc(limit=4)}"
-    send_message(message, env.ADMIN_NUMBER)
+    send_message(message, env.ADMIN_CONTACT)

--- a/signal_scanner_bot/signal.py
+++ b/signal_scanner_bot/signal.py
@@ -12,8 +12,18 @@ log = logging.getLogger(__name__)
 ################################################################################
 # Send message
 ################################################################################
-def send_message(message: str, recipient: Optional[str], group: bool = False):
-    recipient_args = ["-g", str(recipient)] if group else [str(recipient)]
+def send_message(message: str, recipient: Optional[str]):
+    recipient = recipient or ""
+    if recipient.endswith("=="):
+        # Heuristic: this is usually the pattern of group IDs
+        group = True
+    elif recipient.startswith("+"):
+        # Heuristic: this is what phone numbers have to start with
+        group = False
+    else:
+        raise ValueError(f"Supplied recipient is invalid: {recipient}")
+
+    recipient_args = ["-g", recipient] if group else [recipient]
     log.debug("Acquiring signal lock to send")
     with env.SIGNAL_LOCK:
         log.debug("Send lock acquired")

--- a/signal_scanner_bot/signal.py
+++ b/signal_scanner_bot/signal.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 ################################################################################
 def send_message(message: str, recipient: Optional[str]):
     recipient = recipient or ""
-    if recipient.endswith("=="):
+    if recipient.endswith("==") and len(recipient) == 24:
         # Heuristic: this is usually the pattern of group IDs
         group = True
     elif recipient.startswith("+"):


### PR DESCRIPTION
This PR updates the `signal.send_message` API so that the function now automatically detects whether the recipient is a group or an individual. This removes the need for specifying the `group` keyword when calling the function, and allows us to define the admin number as an admin group.

Since the app is now agnostic to groups/individuals, I've also renamed the environment variables to be `_CONTACT` (rather than `_NUMBER` or `_GROUP`).

Tested that this works appropriately with the `signal.panic` function with the `ADMIN_CONTACT` as a group.

Resolves #31 
