### PR TITLE
Re-add removed logging line, add state file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # IDE
 .idea/
+
+# Auto scanner file
+.autoscanner-state-file

--- a/signal_scanner_bot/messages.py
+++ b/signal_scanner_bot/messages.py
@@ -80,6 +80,7 @@ def process_signal_message(blob: Dict, api: API) -> None:
     # Check if twitter-to-signal should be on/off
     condensed = _condense_command(message)
     notice = env.STATE.update_listening_status(condensed)
+    log.info(notice)
     signal.send_message(notice, env.LISTEN_CONTACT)
 
 


### PR DESCRIPTION
This PR re-adds a logging line that was removed in #36, and also adds the default auto scanner state file to the gitignore.
