### PR TITLE
Ignore status messages that don't match auto scan

### DIFF
--- a/signal_scanner_bot/env.py
+++ b/signal_scanner_bot/env.py
@@ -2,7 +2,7 @@ import logging
 import os
 from pathlib import Path
 from threading import Lock
-from typing import Any, Callable, List, Set
+from typing import Any, Callable, List, Set, Optional
 
 
 log = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ class _State:
 
     # Method to update the listening status of the State class
     # object. Checks for on/off and creates/deletes state file.
-    def update_listening_status(self, status: str) -> str:
+    def update_listening_status(self, status: str) -> Optional[str]:
         if status == START_LISTENING:
             self.LISTENING = True
             self.file.touch()
@@ -37,9 +37,7 @@ class _State:
             self.file.unlink(missing_ok=True)
             return STOP_LISTENING_NOTIFICATION
         else:
-            raise ValueError(
-                f"Value {status} provided to _State object, expected {START_LISTENING} or {STOP_LISTENING}."
-            )
+            return None
 
     # Method to return the current state notification message
     def get_listening_status_notice(self) -> str:

--- a/signal_scanner_bot/messages.py
+++ b/signal_scanner_bot/messages.py
@@ -80,8 +80,9 @@ def process_signal_message(blob: Dict, api: API) -> None:
     # Check if twitter-to-signal should be on/off
     condensed = _condense_command(message)
     notice = env.STATE.update_listening_status(condensed)
-    log.info(notice)
-    signal.send_message(notice, env.LISTEN_CONTACT)
+    if notice:
+        log.info(notice)
+        signal.send_message(notice, env.LISTEN_CONTACT)
 
 
 def process_twitter_message(status: Status) -> None:


### PR DESCRIPTION
This PR fixes an issue where all messages sent into the listen group were passed to the state update function, which then raised an exception because the message was not identified as an auto-scan command.

Now, all messages still go to the update state function, but non-matching messages are ignored and a notice is only sent out if the message matches.