### PR TITLE
Upgrade signal-cli version to support V2 groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-slim
 ENV PIP_NO_CACHE_DIR=1 \
     JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/ \
     PYTHONPATH=/app \
-    SIGNAL_CLI_VERSION=0.6.10
+    SIGNAL_CLI_VERSION=0.7.0
 
 # Install OpenJDK-8
 RUN apt-get update && \


### PR DESCRIPTION
Resolves #44

I've verified this upgrade works by making a new V2 group and inviting the test bot to said group. Previous attempts would throw an error in Signal, but this time it worked great! The bot was able to send and receive messages under this version (although I did not test sending to a V2 group...I think it should work fine).

This is the prelude to the group migration we will need to do next. As part of the migration, we will likely need to re-register the number once we upgrade, as well as update the various contact groups.
