### PR TITLE
HOTFIX: V2 group message processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Dumb macOS files
 .DS_Store
+
+# Vim swap files
+*.swp

--- a/signal_scanner_bot/signal.py
+++ b/signal_scanner_bot/signal.py
@@ -18,7 +18,7 @@ def _check_group(recipient: str) -> bool:
     Function to check whether a supplied recipient string is in the phone number
     or group format.
     """
-    if recipient.endswith("==") and len(recipient) == 24:
+    if recipient.endswith("=") and len(recipient) in {24, 44}:
         # Heuristic: this is usually the pattern of group IDs
         return True
     elif recipient.startswith("+"):


### PR DESCRIPTION
This PR is a hotfix for the issue described in #48. It includes 3 changes:
- Support V2 group format in group message sending code
- Add vim swap files to gitignore
- HOTFIX: Add shim function to fake JSON data

Group message info is missing in the `--json` format messages with the current version of the CLI. We can get the information we need if we revert back to the plain-text versions, but then we have to do text processing. This hotfix uses regex to extract the necessary information from the messages and creates a JSON block similar to what should be returned from CLI pre-bug.

I've tested that this works for both ends of the stream. The only trouble we run into is when messages have more than two newlines in a row, but we almost never do that when scanning.

This PR will need to be **fast-forward merged**, so that the hotfix commit can be reverted independently of the other changes.
