### PR TITLE
Comradely reminder loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 BOT_NUMBER=phone number the bot uses, starting with +(countrycode)
-ADMIN_CONTACT=phone number to contact in case something goes wrong, starting with +(countrycode)
-LISTEN_CONTACT=signal groupId for the group to listen to
+ADMIN_CONTACT=phone number or group ID to contact in case something goes wrong, starting with +(countrycode)
+LISTEN_CONTACT=signal group ID for the group to listen to
 TWITTER_API_KEY=Twitter API key
 TWITTER_API_SECRET=Twitter API secret
 TWITTER_ACCESS_TOKEN=Twitter access token
@@ -12,3 +12,6 @@ SIGNAL_MESSAGE_HEADERS=csv of Signal message headers to monitor. Example RESPONS
 AUTOSCAN_STATE_FILE_PATH=Unix path to store the statefile relative to the /app directory. Default is signal_scanner_bot/.autoscanner-state-file. This is an advanced parameter and likely should never be changed unless you have a specific need. If you do set this parameter it is important to store it in a place that will persist over container reloads, ie. the volumes mounted by the docker-compose file (currently signal-cli:/app/data/signal-cli, or ./signal_scanner_bot:/app/signal_scanner_bot).
 TESTING=True or False
 DEBUG=True or False
+COMRADELY_CONTACT=signal group ID to send the message to
+COMRADELY_MESSAGE=contents of the message to send
+COMRADELY_TIME=time to send the message, needs to be in ISO format (e.g. 20:00:00)

--- a/.env.example
+++ b/.env.example
@@ -14,4 +14,4 @@ TESTING=True or False
 DEBUG=True or False
 COMRADELY_CONTACT=signal group ID to send the message to
 COMRADELY_MESSAGE=contents of the message to send
-COMRADELY_TIME=time to send the message, needs to be in ISO format (e.g. 20:00:00)
+COMRADELY_TIME=time to send the message, needs to be in ISO format and UTC timezone (e.g. 20:00:00)

--- a/README.md
+++ b/README.md
@@ -44,10 +44,16 @@ This loop uses `tweepy`'s streaming API to "track" certain hashtags.
 Similar to the S2T loop, messages pass through filters to see if the criteria is met.
 If it is, the `signal-cli` lock is acquired and the contents of the Tweet is sent to the desired Signal group.
 
+### Hierarchy
+
+* The `env` module supplies environment information/secrets to all loops.
+* The `filter` module is used to define message filters for both Signal & Twitter.
+* The `signal` and `twitter` modules compose the basic building blocks of sending/reading to each platform.
+* The `messages` module combines both Signal & Twitter functionality into higher level `process_*` functions.
+* Lastly, the `transport` module defines the primary read/send loops, using the process functions defined in `messages`.
+
 ### Issues
 Both of these loops use `ascynio` to run concurrently, but as stated above they share the `signal-cli` lock
 Already I've noticed some issues with this setup that I'm hoping to address in the future:
 * T2S messages take a long time to actually get sent
 * Even with the lock, the CLI in the T2S loop still complains that signal is in use and the CLI lock requires some time to be acquired
-* When Twitter traffic on the tracked hashtag is high, the tweepy stream gets closed by Twitter because the messages aren't handled quickly enough
-* When a lot of messages are trying to be sent out in succession by the T2S loop, the `signal-cli` has been giving 413 rate limiting errors

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# type: ignore
 #
 # signal_scanner_bot documentation build configuration file, created by
 # sphinx-quickstart on Fri Jun  9 13:47:02 2017.

--- a/signal_scanner_bot/bin/run.py
+++ b/signal_scanner_bot/bin/run.py
@@ -9,6 +9,7 @@ from signal_scanner_bot.transport import (
     signal_to_twitter,
     twitter_to_queue,
     queue_to_signal,
+    comradely_reminder,
 )
 
 
@@ -42,6 +43,7 @@ def cli(debug: bool = False) -> None:
             signal_to_twitter(),
             queue_to_signal(),
             twitter_to_queue(),
+            comradely_reminder(),
             return_exceptions=True,
         )
     )

--- a/signal_scanner_bot/env.py
+++ b/signal_scanner_bot/env.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from asyncio import Queue
+from datetime import time
 from pathlib import Path
 from threading import Lock
 from typing import Any, Callable, List, Set, Optional
@@ -124,6 +125,10 @@ def _cast_to_path(to_cast: str) -> Path:
     return Path(to_cast)
 
 
+def _cast_to_time(to_cast: str) -> time:
+    return time.fromisoformat(to_cast)
+
+
 def _format_hashtags(to_cast: str) -> List[str]:
     hashtags = _cast_to_list(to_cast)
     if any("#" in hashtag for hashtag in hashtags):
@@ -159,6 +164,14 @@ AUTOSCAN_STATE_FILE_PATH = _env(
     "AUTOSCAN_STATE_FILE_PATH",
     convert=_cast_to_path,
     default="signal_scanner_bot/.autoscanner-state-file",
+)
+COMRADELY_CONTACT = _env("COMRADELY_CONTACT", convert=_cast_to_string, fail=False)
+COMRADELY_MESSAGE = _env("COMRADELY_MESSAGE", convert=_cast_to_string, fail=False)
+COMRADELY_TIME = _env(
+    "COMRADELY_TIME",
+    convert=_cast_to_time,
+    fail=False,
+    default="10:00:00",  # 2pm PST
 )
 
 # Checking to ensure user ids are in the proper format, raise error if not.

--- a/signal_scanner_bot/env.py
+++ b/signal_scanner_bot/env.py
@@ -171,7 +171,7 @@ COMRADELY_TIME = _env(
     "COMRADELY_TIME",
     convert=_cast_to_time,
     fail=False,
-    default="10:00:00",  # 2pm PST
+    default="20:00:00",  # 2pm PST
 )
 
 # Checking to ensure user ids are in the proper format, raise error if not.

--- a/signal_scanner_bot/env.py
+++ b/signal_scanner_bot/env.py
@@ -3,7 +3,6 @@ import os
 from asyncio import Queue
 from datetime import time
 from pathlib import Path
-from threading import Lock
 from typing import Any, Callable, List, Set, Optional
 
 
@@ -185,7 +184,6 @@ for tweeter in TRUSTED_TWEETERS:
 ################################################################################
 # Environment State Variables
 ################################################################################
-SIGNAL_LOCK = Lock()
 STATE = _State(AUTOSCAN_STATE_FILE_PATH)
 TWITTER_TO_SIGNAL_QUEUE: Queue = Queue(maxsize=10000)  # shooting from the hip here...
 

--- a/signal_scanner_bot/messages.py
+++ b/signal_scanner_bot/messages.py
@@ -159,3 +159,13 @@ async def process_twitter_message(status: Dict) -> None:
     # On the off chance a message is an empty string just skip sending
     if message:
         await env.TWITTER_TO_SIGNAL_QUEUE.put(message)
+
+
+async def send_comradely_reminder() -> None:
+    """
+    Send a comradely reminder.
+    """
+    if not (env.COMRADELY_CONTACT and env.COMRADELY_MESSAGE):
+        return
+    log.info("Sending comradely message")
+    signal.send_message(env.COMRADELY_MESSAGE, env.COMRADELY_CONTACT)

--- a/signal_scanner_bot/signal.py
+++ b/signal_scanner_bot/signal.py
@@ -94,22 +94,20 @@ def send_message(message: str, recipient: str):
     group = _check_group(recipient)
     recipient_args = ["-g", recipient] if group else [recipient]
 
-    log.debug("Acquiring signal lock to send")
-    with env.SIGNAL_LOCK:
-        log.debug("Send lock acquired")
-        proc = subprocess.run(
-            [
-                "signal-cli",
-                "-u",
-                str(env.BOT_NUMBER),
-                "send",
-                "-m",
-                message,
-                *recipient_args,
-            ],
-            capture_output=True,
-            text=True,
-        )
+    log.debug("Sending message")
+    proc = subprocess.run(
+        [
+            "signal-cli",
+            "-u",
+            str(env.BOT_NUMBER),
+            "send",
+            "-m",
+            message,
+            *recipient_args,
+        ],
+        capture_output=True,
+        text=True,
+    )
     if proc.stdout:
         log.info(f"STDOUT: {proc.stdout}")
     if proc.stderr:

--- a/signal_scanner_bot/signal.py
+++ b/signal_scanner_bot/signal.py
@@ -49,12 +49,11 @@ def list_identities() -> List[str]:
     """
     Function that calls the signal-cli `listIdentities` command and returns the entire result as a string
     """
-    with env.SIGNAL_LOCK:
-        proc = subprocess.run(
-            ["signal-cli", "-u", str(env.BOT_NUMBER), "listIdentities"],
-            capture_output=True,
-            text=True,
-        )
+    proc = subprocess.run(
+        ["signal-cli", "-u", str(env.BOT_NUMBER), "listIdentities"],
+        capture_output=True,
+        text=True,
+    )
     if proc.stderr:
         log.warning(f"STDERR: {proc.stderr}")
     if proc.stdout:
@@ -67,24 +66,23 @@ def trust_identity(phone_number: str, safety_number: str):
     """
     Function that calls the signal-cli `trust` command for the provided phone + safety numbers
     """
-    with env.SIGNAL_LOCK:
-        proc = subprocess.run(
-            [
-                "signal-cli",
-                "-u",
-                str(env.BOT_NUMBER),
-                "trust",
-                phone_number,
-                "-v",
-                f'"{safety_number}"',
-            ],
-            capture_output=False,
-            text=True,
-        )
-        if proc.stderr:
-            log.error(f"STDERR: {proc.stderr}")
-        if proc.returncode != 0:
-            log.error(f"Trust call return code: {proc.returncode}")
+    proc = subprocess.run(
+        [
+            "signal-cli",
+            "-u",
+            str(env.BOT_NUMBER),
+            "trust",
+            phone_number,
+            "-v",
+            f'"{safety_number}"',
+        ],
+        capture_output=False,
+        text=True,
+    )
+    if proc.stderr:
+        log.error(f"STDERR: {proc.stderr}")
+    if proc.returncode != 0:
+        log.error(f"Trust call return code: {proc.returncode}")
 
 
 def send_message(message: str, recipient: str):

--- a/signal_scanner_bot/transport.py
+++ b/signal_scanner_bot/transport.py
@@ -4,6 +4,7 @@ import logging
 import re
 import subprocess
 from asyncio import IncompleteReadError
+from datetime import datetime, timedelta
 from typing import Dict
 
 from peony import events
@@ -150,3 +151,24 @@ async def signal_to_twitter():
         except ProcessLookupError:
             log.warning("Failed to kill process, moving on.")
             pass
+
+
+################################################################################
+# Comradely Reminder
+################################################################################
+async def comradely_reminder() -> None:
+    """
+    Top level function for running the comradely reminder loop
+    """
+    try:
+        while True:
+            now = datetime.now().time()
+            start = env.COMRADELY_TIME
+            # Check if we're currently within a 1-hour time window
+            if start <= now < (start + timedelta(hours=1)):
+                await messages.send_comradely_reminder()
+            # Wait at least 60 minutes for the next check
+            await asyncio.sleep(60 * 60)
+    except Exception as err:
+        signal.panic(err)
+        raise

--- a/signal_scanner_bot/transport.py
+++ b/signal_scanner_bot/transport.py
@@ -112,9 +112,9 @@ async def signal_to_twitter():
             # TODO: re-enable JSON
             proc = await asyncio.create_subprocess_shell(
                 f"signal-cli -u {env.BOT_NUMBER} receive -t {env.SIGNAL_TIMEOUT}",
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
             try:
                 # V2 non-json messages are separated by two newlines
                 while line := await proc.stdout.readuntil(separator=b"\n\n"):
@@ -158,6 +158,8 @@ async def comradely_reminder() -> None:
     """
     Top level function for running the comradely reminder loop
     """
+    # Wait for system to initialize...
+    await asyncio.sleep(15)
     try:
         window_start = env.COMRADELY_TIME
         # Can't do arithmetic with python time objects...

--- a/signal_scanner_bot/transport.py
+++ b/signal_scanner_bot/transport.py
@@ -108,12 +108,10 @@ async def signal_to_twitter():
     """
     try:
         while not env.STATE.STOP_REQUESTED:
-            log.debug("Acquiring lock to listen for Signal messages")
-            with env.SIGNAL_LOCK:
-                log.debug("Listen lock for Signal messages acquired")
-                # TODO: re-enable JSON
-                proc = await asyncio.create_subprocess_shell(
-                    f"signal-cli -u {env.BOT_NUMBER} receive -t {env.SIGNAL_TIMEOUT}",
+            log.debug("Listening on signal")
+            # TODO: re-enable JSON
+            proc = await asyncio.create_subprocess_shell(
+                f"signal-cli -u {env.BOT_NUMBER} receive -t {env.SIGNAL_TIMEOUT}",
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                 )


### PR DESCRIPTION
Resolves #53

This PR adds a "comradely reminder" loop to the series of main loops that are ongoing. This loop can be configured to send out a message around a certain time and to a certain contact group. Tested this locally with success!

I also removed the signal lock mechanisms, because they were redundant to signal-cli's own internal lock.
