### PR TITLE
Bugfix: Identity list regex, safety number interpolation

### DIFF
--- a/signal_scanner_bot/bin/verify.py
+++ b/signal_scanner_bot/bin/verify.py
@@ -16,10 +16,7 @@ logging.basicConfig(
 
 # Constants
 UNTRUSTED_REGEX = re.compile(
-    r"""
-^(?P<phone_number>\+[1-9]\d{10}): UNTRUSTED .* Safety Number: (?P<safety_number>[0-9 ]*)
-""",
-    flags=re.MULTILINE,
+    r"^(?P<phone_number>\+[1-9]\d{10}): UNTRUSTED .* Safety Number: (?P<safety_number>[0-9 ]*)"
 )
 
 

--- a/signal_scanner_bot/signal.py
+++ b/signal_scanner_bot/signal.py
@@ -74,7 +74,7 @@ def trust_identity(phone_number: str, safety_number: str):
             "trust",
             phone_number,
             "-v",
-            f'"{safety_number}"',
+            f'{safety_number.replace(" ", "")}',
         ],
         capture_output=False,
         text=True,


### PR DESCRIPTION
Resolves #57

This PR fixes two issues:

1. The regex was failing to match because there were newlines as a result of me making the compliation a docstring.
1. The interpolation of the safety number into the CLI was failing because of some errant spaces.
