### PR TITLE
Change container restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     volumes:
       - signal-cli:/app/data/signal-cli
       - ./signal_scanner_bot:/app/signal_scanner_bot
-    restart: always
+    restart: unless-stopped
 volumes:
   signal-cli:


### PR DESCRIPTION
I just rebooted my computer and was reminded of the fact that `restart: always` starts the container up when my computer boots. `unless-stopped` should be sufficient in this case.
