### PR TITLE
Add release version name to dockerhub tags

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install Dependencies
-        run: pip install mypy
+        run: pip install mypy types-ujson
       - name: Check typing with mypy
         run: mypy .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Set release verison env
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+        run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
       - name: Build and push to DockerHub
         uses: docker/build-push-action@v2
         with:
@@ -29,5 +29,5 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            sdsa/signal-scanner-bot:$RELEASE_VERSION
+            sdsa/signal-scanner-bot:${{ env.RELEASE_VERSION }}
             sdsa/signal-scanner-bot:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Set release verison env
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
       - name: Build and push to DockerHub
         uses: docker/build-push-action@v2
         with:
@@ -27,4 +29,5 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
+            sdsa/signal-scanner-bot:$RELEASE_VERSION
             sdsa/signal-scanner-bot:latest


### PR DESCRIPTION
This _should_ make it so that a new release will push to the `latest` tag and also the tagged version (e.g. `v1.0.2`)
