### PR TITLE
Bump peony version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Click==7.1.2
-peony-twitter==1.1.7
+peony-twitter==2.0.2
 pre-commit==2.9.0
 tweepy==3.9.0
 ujson==3.1.0


### PR DESCRIPTION
Small PR to bump the peony version. The twitter-to-queue stream stopped working at some point for reasons I don't quite understand, possibly an API change or something. This addresses the issue, at least from what I can tell with local testing.
