### PR TITLE
Bugfix: don't consider receipt messages malformed

### DIFF
--- a/signal_scanner_bot/messages.py
+++ b/signal_scanner_bot/messages.py
@@ -107,7 +107,9 @@ async def process_signal_message(blob: Dict, client: peony.PeonyClient) -> None:
     """
     log.debug(f"Got message: {blob}")
     envelope = blob.get("envelope", {})
-    if not envelope or "dataMessage" not in envelope:
+    if not envelope or (
+        "dataMessage" not in envelope and "receiptMessage" not in envelope
+    ):
         log.error(f"Malformed message: {blob}")
 
     data = envelope.get("dataMessage") or {}


### PR DESCRIPTION
We were getting a lot of log messages like this:

```
cli_1  | [2021-09-10 04:22:07,410 - signal_scanner_bot.messages - 111][ERROR] Malformed message: {'envelope': {'source': '<redacted>', 'sourceDevice': 3, 'timestamp': 1631247723757, 'receiptMessage': {'when': 1631247723757, 'isDelivery': True, 'isRead': False, 'timestamps': [1631247719921]}}}
cli_1  | [2021-09-10 04:22:07,423 - signal_scanner_bot.messages - 111][ERROR] Malformed message: {'envelope': {'source': '<redacted>', 'sourceDevice': 1, 'timestamp': 1631247723704, 'receiptMessage': {'when': 1631247723704, 'isDelivery': True, 'isRead': False, 'timestamps': [1631247719921]}}}
cli_1  | [2021-09-10 04:22:07,438 - signal_scanner_bot.messages - 111][ERROR] Malformed message: {'envelope': {'source': '<redacted>', 'sourceDevice': 1, 'timestamp': 1631247723471, 'receiptMessage': {'when': 1631247723471, 'isDelivery': True, 'isRead': False, 'timestamps': [1631247719921]}}}
cli_1  | [2021-09-10 04:22:07,464 - signal_scanner_bot.messages - 111][ERROR] Malformed message: {'envelope': {'source': '<redacted>', 'sourceDevice': 1, 'timestamp': 1631247721505, 'receiptMessage': {'when': 1631247721505, 'isDelivery': True, 'isRead': False, 'timestamps': [1631247719921]}}}
cli_1  | [2021-09-10 04:22:07,491 - signal_scanner_bot.messages - 111][ERROR] Malformed message: {'envelope': {'source': '<redacted>', 'sourceDevice': 1, 'timestamp': 1631247726286, 'receiptMessage': {'when': 1631247726286, 'isDelivery': True, 'isRead': False, 'timestamps': [1631247719921]}}}
```

These are just delivery receipts which we're now seeing due to changes in the Signal API. This PR changes the ckeck to pass these onto the rest of the filters and NOT consider them malformed.

When I have the time _(HAHAHAHAHAHAHAHA hahaha wow whew ha, what a joke)_ I should have more comprehensive tests for this.
