### PR TITLE
Implement backoff decorator for check_radio_calls function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,4 +21,5 @@ RADIO_MONITOR_UNITS=CSV of units to be looking for on radio IDs, case insensitiv
 RADIO_MONITOR_CONTACT=signal group ID to send the message to
 RADIO_MONITOR_LOOKBACK=Basically the check interval for looking for new calls from openmhz. Time value is in seconds and must be at least 45 or greater. If not set or less than 45 the interval will be set for 45 seconds.
 RADIO_AUDIO_CHUNK_SIZE=How many bytes to read when downloading an audio file from OpenMhz. Defaults to 10 bytes. Probably shouldn't be changed.
+RADIO_CHASER_BACKOFF=The amount of time in seconds to backoff on the OpenMHz site for
 DEFAULT_TZ=TZ database formatted name for a timezone. Defaults to US/Pacific

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiofiles>=0.7.0
 aiohttp>=3.7.4
+backoff>=1.11.1
 Click==7.1.2
 peony-twitter==2.0.2
 pre-commit==2.9.0

--- a/signal_scanner_bot/env.py
+++ b/signal_scanner_bot/env.py
@@ -203,6 +203,9 @@ RADIO_MONITOR_LOOKBACK = _env(
 RADIO_AUDIO_CHUNK_SIZE = _env(
     "RADIO_AUDIO_CHUNK_SIZE", convert=_cast_to_int, fail=False, default=10
 )
+RADIO_CHASER_BACKOFF = _env(
+    "RRADIO_CHASER_BACKOFF", convert=_cast_to_int, fail=False, default=10800
+)
 
 # Check to make sure the lookback interval is greater than or equal to 45 seconds
 if RADIO_MONITOR_LOOKBACK < 45:

--- a/signal_scanner_bot/radio_monitor_alert.py
+++ b/signal_scanner_bot/radio_monitor_alert.py
@@ -47,6 +47,17 @@ async def get_pigs(calls: Dict) -> List[Tuple[Dict, str, str]]:
     interesting_pigs = []
     for call in calls:
         time = call["time"]
+        # Due to requirements from aiohttp library it is required that the radios object be
+        # of the forms:
+        #  * {'key1': 'value1', 'key2': 'value2'}
+        #  * {"key": ["value1", "value2"]}
+        #  * [("key", "value1"), ("key", "value2")]
+        #
+        # more pointedly, it can not be
+        #  * {"key": {"value1", "value2"}}
+        #
+        # because aiohttp will choke on it. See the following link for more details
+        # https://docs.aiohttp.org/en/stable/client_quickstart.html#passing-parameters-in-urls
         radios = {"radio": list({f"7{radio['src']:0>5}" for radio in call["srcList"]})}
         if not len(radios["radio"]):
             continue

--- a/signal_scanner_bot/radio_monitor_alert.py
+++ b/signal_scanner_bot/radio_monitor_alert.py
@@ -48,7 +48,7 @@ async def get_pigs(calls: Dict) -> List[Tuple[Dict, str, str]]:
     for call in calls:
         time = call["time"]
         radios = {"radio": list({f"7{radio['src']:0>5}" for radio in call["srcList"]})}
-        if not len(radios):
+        if not len(radios["radio"]):
             continue
         async with aiohttp.ClientSession(raise_for_status=True) as session:
             async with session.get(env.RADIO_CHASER_URL, params=radios) as response:

--- a/signal_scanner_bot/transport.py
+++ b/signal_scanner_bot/transport.py
@@ -1,6 +1,5 @@
 """Main module."""
 import asyncio
-import json
 import logging
 import subprocess
 from datetime import date, datetime, timedelta
@@ -146,7 +145,9 @@ async def radio_monitor_alert_transport() -> None:
     while True:
         try:
             log.debug("Checking for monitored units' radio activity.")
-            if radio_monitor_alert_messages := radio_monitor_alert.check_radio_calls():
+            if (
+                radio_monitor_alert_messages := await radio_monitor_alert.check_radio_calls()
+            ):
                 log.info(
                     "Radio activity found for monitored units sending alert to group."
                 )
@@ -159,11 +160,6 @@ async def radio_monitor_alert_transport() -> None:
                 f"Sleeping for {env.RADIO_MONITOR_LOOKBACK}s before checking for monitored unit alerts again."
             )
             await asyncio.sleep(env.RADIO_MONITOR_LOOKBACK)
-        except json.decoder.JSONDecodeError:
-            # Sometimes OpenMHz doesn't return properly and the Python json library throws this error.
-            # It is transient and so doesn't really need to panic or throw an exception, so we will
-            # ignore it.
-            pass
         except Exception as err:
             log.exception(err)
             signal.panic(err)


### PR DESCRIPTION
OpenMHz is not always reliable, so to get around it I'm implementing a backoff function that will wait for a default of 2 hours. This is now set by the .env setting RADIO_CHASER_BACKOFF