### PR TITLE
Bump signal-cli to 0.10.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
             - --select=B,C,E,F,W,T4,B9
 
   - repo: https://github.com/ambv/black
-    rev: 21.6b0
+    rev: 22.3.0
     hooks:
         - id: black
           args:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-slim
 ENV PIP_NO_CACHE_DIR=1 \
     JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/ \
     PYTHONPATH=/app \
-    SIGNAL_CLI_VERSION=0.9.1
+    SIGNAL_CLI_VERSION=0.10.5
 
 # Install OpenJDK-8
 RUN apt-get update && \
@@ -18,8 +18,8 @@ RUN apt-get update && \
 
 # Install signal-cli
 WORKDIR /tmp
-RUN wget -q https://github.com/AsamK/signal-cli/releases/download/v${SIGNAL_CLI_VERSION}/signal-cli-${SIGNAL_CLI_VERSION}.tar.gz && \
-    tar xf /tmp/signal-cli-${SIGNAL_CLI_VERSION}.tar.gz -C /opt && \
+RUN wget -q https://github.com/AsamK/signal-cli/releases/download/v${SIGNAL_CLI_VERSION}/signal-cli-${SIGNAL_CLI_VERSION}-Linux.tar.gz && \
+    tar xf /tmp/signal-cli-${SIGNAL_CLI_VERSION}-Linux.tar.gz -C /opt && \
     ln -sf /opt/signal-cli-${SIGNAL_CLI_VERSION}/bin/signal-cli /usr/local/bin/
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
-FROM python:3.8-slim
+FROM openjdk:17-slim
 
 ENV PIP_NO_CACHE_DIR=1 \
-    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/ \
     PYTHONPATH=/app \
     SIGNAL_CLI_VERSION=0.10.5
 
 # Install OpenJDK-8
 RUN apt-get update && \
-    mkdir -p /usr/share/man/man1 && \
     apt-get install -y \
-        default-jre \
+        python3.9 \
+        python3.9-dev \
+        python3-pip \
         wget \
+        openjdk-17-jdk-headless \
+        openjdk-17-jre-headless \
         ca-certificates-java \
         dos2unix && \
     rm -rf /var/lib/apt/lists/* && \

--- a/justfile
+++ b/justfile
@@ -28,8 +28,8 @@ pull:
     {{ DC }} pull
 
 # Follow docker logs
-logs:
-    {{ DC }} logs -f
+logs args="":
+    {{ DC }} logs -f {{ args }}
 
 # Verify all numbers
 verify:

--- a/justfile
+++ b/justfile
@@ -27,6 +27,10 @@ down:
 pull:
     {{ DC }} pull
 
+# Follow docker logs
+logs:
+    {{ DC }} logs -f
+
 # Verify all numbers
 verify:
 	{{ DC }} {{ RUN }} signal-scanner-bot-verify


### PR DESCRIPTION
This was quite a doozy - signal-cli version 0.10.0 [required using Java 17 rather than Java 11](https://github.com/AsamK/signal-cli/blob/master/CHANGELOG.md#0100---2021-12-11). Unfortunately, Java is a PITA to install and I have no idea how to install a non-default version inside a Docker container. So instead of installing Java within a Python image, we're installing Python within a Java image. The upshot of this is that:

* Our base image is now `openjdk:17-slim` rather than `python:3.8-slim`
* `openjdk` has access to Python 3.9 only by default, so we've upgraded to Python 3.9
* signal-cli is now at v0.10.5

I've also added a `just logs` recipe, which has been useful for debugging and in other projects.

I haven't _actually_ tested this beyond `docker-compose run --rm cli bash` -> `signal-cli --version`, because we lost the test number and it would be a huge pain to try and get a new number registered and set up with all the testing groups.

### Testing instructions
1. `just build`
2. `docker-compose run --rm cli bash`
3. `signal-cli --version` should print out `signal-cli 0.10.5` and shouldn't complain about Java version.
