### PR TITLE
Update java to 17, signal-cli to v0.11.7

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install Dependencies
         run: pip install pre-commit
       - name: Run static checks
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install Dependencies
         run: pip install pytest pytest-cov
       - name: Test with pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: python-no-log-warn
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: Run isort to sort imports

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
-FROM python:3.8-slim
+FROM python:3.11-slim
+
+ENV JDK_VERSION=17 \
+    SIGNAL_CLI_VERSION=0.11.7
 
 ENV PIP_NO_CACHE_DIR=1 \
-    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/ \
     PYTHONPATH=/app \
-    SIGNAL_CLI_VERSION=0.9.1
+    JAVA_HOME=/usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/
 
 # Install OpenJDK-8
 RUN apt-get update && \
     mkdir -p /usr/share/man/man1 && \
     apt-get install -y \
-        default-jre \
+        openjdk-${JDK_VERSION}-jdk \
+        openjdk-${JDK_VERSION}-jre \
         wget \
         ca-certificates-java \
         dos2unix && \
@@ -18,8 +21,8 @@ RUN apt-get update && \
 
 # Install signal-cli
 WORKDIR /tmp
-RUN wget -q https://github.com/AsamK/signal-cli/releases/download/v${SIGNAL_CLI_VERSION}/signal-cli-${SIGNAL_CLI_VERSION}.tar.gz && \
-    tar xf /tmp/signal-cli-${SIGNAL_CLI_VERSION}.tar.gz -C /opt && \
+RUN wget -q https://github.com/AsamK/signal-cli/releases/download/v${SIGNAL_CLI_VERSION}/signal-cli-${SIGNAL_CLI_VERSION}-Linux.tar.gz && \
+    tar xf /tmp/signal-cli-${SIGNAL_CLI_VERSION}-Linux.tar.gz -C /opt && \
     ln -sf /opt/signal-cli-${SIGNAL_CLI_VERSION}/bin/signal-cli /usr/local/bin/
 
 WORKDIR /app

--- a/justfile
+++ b/justfile
@@ -5,6 +5,9 @@ COMPOSE_FILE := "--file=docker-compose.yml" + (
 )
 DC := "docker-compose " + COMPOSE_FILE
 RUN := "run --rm cli"
+# Force just to hand down positional arguments so quoted arguments with spaces are
+# handled appropriately
+set positional-arguments
 
 
 # Show all available recipes
@@ -27,6 +30,14 @@ down:
 pull:
     {{ DC }} pull
 
+# Attach logs to all (or the specified) services
+logs *args:
+	{{ DC }} logs -f {{ args }}
+
+# Run a command on a provided service
+run *args:
+	{{ DC }} {{ RUN }} "$@"
+
 # Verify all numbers
 verify:
 	{{ DC }} {{ RUN }} signal-scanner-bot-verify
@@ -36,5 +47,5 @@ register:
 	{{ DC }} {{ RUN }} ./register-number.sh
 
 # Static checks
-static:
+lint:
 	pre-commit run --all-files

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp>=3.7.4
 backoff>=1.11.1
 Click==7.1.2
 peony-twitter==2.0.2
-pre-commit==2.9.0
+pre-commit==3.2.1
 python-dotenv==0.19.2
 pytz>=2021.3
 requests==2.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ python-dotenv==0.19.2
 pytz>=2021.3
 requests==2.26.0
 tweepy==3.9.0
-ujson==3.1.0
+ujson==5.7.0
 urllib3==1.26.5


### PR DESCRIPTION
Follow up to #87, almost a year later! Same notes still apply:

- Update Java to version 17 from 11 for compatibility with the newer version of signal-cli
- Update system python to 3.11
- Add more recipes to `justfile`

Still couldn't test this because the number is long gone, there'll probably be follow up once we try running this on prod.
